### PR TITLE
Add de-go.kelkoogroup.net

### DIFF
--- a/domains
+++ b/domains
@@ -325,6 +325,7 @@ customtraffic.impactradius.com # CNAME of goto.target.com
 cz-go.kelkoogroup.net
 dart.l.doubleclick.net # CNAME of ad.doubleclick.net
 dashboard-01.braze.com
+de-go.kelkoogroup.net
 dk-go.kelkoogroup.net
 dpbolvw.net
 ea.galerieslafayette.com


### PR DESCRIPTION
Missing *-go.kelkoogroup.net domain for Germany. Used as referral domain for ads in DuckDuckGo search results.

[Testlink OTTO](https://links.duckduckgo.com/m.js?dsl=1&iurl=%7B1%7DIG%3DBD23D54C42F246648F567B8122F2DD3D%26CID%3D23F2E2CEC5A36C3736DDF0A1C4F46DD9%26ID%3DDevEx%2C5176.1&ivu=%7B4%7Dtype%3Dmv%26reqver%3D1.0%26rg%3Dda5e8c29bd694957a80b6819d07222cf&sfexp=0&shopping=1&spld=%7B%22ld%22%3A%22e8PV10YnEurq9thfY24EgYZDVUCUxP1YMm5ARsTzleSpXUMdGeNcsozdd775O7E4qNGLY9DDMzTYnhSOhEIQ0ynQEl5KvJj1pFxtyboH9iorilt81EYcok4ZgQBXXQzSTcoI_XlHw0a8UDwUwv7CrzCuOPzl6XgstmY1jrz_oXkG4_mPCy%22%2C%22rlid%22%3A%224669cc60e7da1329d9c9afebae7111d2%22%2C%22u%22%3A%22aHR0cHMlM2ElMmYlMmZkZS5zaG9wcGluZ2RlYWwub25saW5lJTJmem9vbS5waHAlM2Z1JTNkYUhSMGNITTZMeTlrWlMxbmJ5NXJaV3hyYjI5bmNtOTFjQzV1WlhRdlkzUnNMMmR2TDI5bVptVnljMlZoY21Ob1IyOF9MblJ6UFRFMk5qazNOamc1T0RneU56TW1Mbk5wWnoxNFVHbExTamRDUVY5eloydHlWR0ZGTVdRM1RrODJaME4wYm1zdEptRm1abWxzYVdGMGFXOXVTV1E5T1RZNU56azNNRFVtWTI5dFNXUTlNelExTkRreU15WmpiM1Z1ZEhKNVBXUmxKbTltWm1WeVNXUTlOVE14T0dabE9EVXpNRFZoWWpGa05HTmhPR0prTURGbE5XVmtaak5qT0dVbWMyVnlkbWxqWlQwek55WjBiMnRsYmtsa1BUTXdOelprT1RVeUxUWXpPVEF0TkRSbE1pMWlaR1UzTFRSaU56aGlOamd4TWpWaE9DWjNZV2wwUFhSeWRXVSUyNmN1c3RvbTElM2QyNQ%22%7D&styp=entitydetails&ad_domain=)