### PR TITLE
Add tracking.s24.com

### DIFF
--- a/domains
+++ b/domains
@@ -442,6 +442,7 @@ track.webgains.com
 trackcmp.net
 tracker.marinsm.com
 tracking.publicidees.com
+tracking.s24.com
 trk.klclick.com
 trk.klclick1.com
 ue.flipboard.com # flipboard newsletter unsubscribe link


### PR DESCRIPTION
Used as referral domain for shopping ads in DuckDuckGo search results.

[Testlink OTTO](https://links.duckduckgo.com/m.js?dsl=1&iurl=%7B1%7DIG%3DBD23D54C42F246648F567B8122F2DD3D%26CID%3D23F2E2CEC5A36C3736DDF0A1C4F46DD9%26ID%3DDevEx%2C5170.1&ivu=%7B4%7Dtype%3Dmv%26reqver%3D1.0%26rg%3Dda5e8c29bd694957a80b6819d07222cf&sfexp=0&shopping=1&spld=%7B%22ld%22%3A%22e8pG43-lVhOWwABpMb_GwD5TVUCUwmsfle_y_sFBpTP2xTArdDSBfApdg1am2IYkybGrDn4WbvnNex6DmA2IGbjTsmGu9LgXenYN8NcCjt1U5Gi8Pr7LBOi-m0ocEyaKi-m9ImBszcXWcXLV_omgSuCAfsCqz0QPOAaIsJIHkSz5r4co_o%22%2C%22rlid%22%3A%22af56bc18b106153e2d0edf93f8ad840e%22%2C%22u%22%3A%22aHR0cHMlM2ElMmYlMmZjbGljay5jYXJ0YWdlb3VzLmRlJTJmJTNmZmN0JTNkdHJ1ZSUyNnBzaWQlM2QxMTU2MiUyNmF1dGglM2R6VmZwciUyNmt3JTNkJTI2JTI2bmV0JTNkYiUyNmZfcHJvZF9pZCUzZDYwMzY2NzQ3NzMlMjZzdWJpZCUzZDQyMjYzMzUwMyU3YzExNjY1ODI3Nzg1OTMxNjMlN2NwbGEtNDU3NjUxMTAxMzUwNTEwMCU3Y3MlN2NjJTdjNzI5MTE2MTE1MjIwNDklN2NwbGEtNDU3NjUxMTAxMzUwNTEwMCU3Y3MlN2NhZjU2YmMxOGIxMDYxNTNlMmQwZWRmOTNmOGFkODQwZSUyNm1zY2xraWQlM2RhZjU2YmMxOGIxMDYxNTNlMmQwZWRmOTNmOGFkODQwZQ%22%7D&styp=entitydetails&ad_domain=)