### PR TITLE
Add rd2szde.bizrate.com

### DIFF
--- a/domains
+++ b/domains
@@ -403,6 +403,7 @@ pt-go.kelkoogroup.net
 qksrv.net
 r20.rs6.net
 rd.bizrate.com # CNAME of link.sylikes.com
+rd2szde.bizrate.com
 rebrandlydomain.com # CNAME of go.blokada.org
 redir.tradedoubler.com
 redirect.at


### PR DESCRIPTION
Used as referral domain for shopping ads in Google search results.

[Testlink](https://www.google.de/aclk?sa=l&ai=DChcSEwjX9MSvyN37AhUItNUKHUVXA0sYABAIGgJ3cw&sig=AOD64_1oxbSPF_MWdkd-f8tA-vtHGirnXg&ctype=5&q=&ved=2ahUKEwjzl7yvyN37AhUThP0HHTv2Aj4Q9aACKAB6BAgFEBM&adurl=)