### PR TITLE
Add ad.dyntracker.de

### DIFF
--- a/domains
+++ b/domains
@@ -5,6 +5,7 @@
 action.metaffiliation.com
 ad.atdmt.com
 ad.doubleclick.net
+ad.dyntracker.de
 adclick.g.doubleclick.net
 adfoc.us
 adj.st


### PR DESCRIPTION
Used as referral domain for shopping ads in Google search results.

[Testlink](https://www.google.de/aclk?sa=l&ai=DChcSEwj8n4H_yd37AhUXzncKHeXnBWQYABAFGgJlZg&sig=AOD64_0od9aOMNmJtp5vXLwQgbSK4NqJ9A&ctype=5&q=&ved=0ahUKEwiyk_3-yd37AhUKxQIHHRX2AKwQww8I1ws&adurl=)