### PR TITLE
Add m.exactag.com

### DIFF
--- a/domains
+++ b/domains
@@ -372,6 +372,7 @@ links.mkt71.net # Click link CNAME for acoustic marketing platform
 links.mkt81.net # Click link CNAME for acoustic marketing platform
 links.mkt91.net # Click link CNAME for acoustic marketing platform
 list-manage.com
+m.exactag.com
 mktoweb.com # Adobe MarkeTo landing page CNAME target
 mmtro.com
 monitor.clickcease.com


### PR DESCRIPTION
Used as referral domain for shopping ads in Google search results.