### PR TITLE
Add media01.eu

### DIFF
--- a/domains
+++ b/domains
@@ -372,6 +372,7 @@ links.mkt71.net # Click link CNAME for acoustic marketing platform
 links.mkt81.net # Click link CNAME for acoustic marketing platform
 links.mkt91.net # Click link CNAME for acoustic marketing platform
 list-manage.com
+media01.eu
 mktoweb.com # Adobe MarkeTo landing page CNAME target
 mmtro.com
 monitor.clickcease.com


### PR DESCRIPTION
Used as referral domain for german ads in Google search results.

[TestLink](https://lidl.media01.eu/set.aspx?trackid=24E7923657B58ACD2168F47A89312161&dt_url=https://www.lidl.de/%3Fmktc%3Dbrandpaidsearch_shop&gclid=CjwKCAiAhKycBhAQEiwAgf19etIASOyMsRO_nCR7a4-9VITGbar80nQmiRoUBhf_jnKjcKmWleFl0RoCvVsQAvD_BwE)