### PR TITLE
Add missing tradedoubler.com

### DIFF
--- a/domains
+++ b/domains
@@ -386,6 +386,7 @@ online.adservicemedia.dk
 online.digital-advisor.com
 open.spotify.com
 pagead.l.doubleclick.net # CNAME of www.googleadservices.com
+pdt.tradedoubler.com
 pepperjamnetwork.com
 pi.pardot.com # CNAME of go.pardot.com
 pixel.everesttech.net
@@ -405,6 +406,7 @@ r20.rs6.net
 rd.bizrate.com # CNAME of link.sylikes.com
 rebrandlydomain.com # CNAME of go.blokada.org
 redir.tradedoubler.com
+redirects.tradedoubler.com
 redirect.at
 redirect.viglink.com
 ro-go.kelkoogroup.net


### PR DESCRIPTION
Add missind tradedoubler.com referral domains, found in DuckDuckGo search results.