### PR TITLE
Adding flx1.com and Sort List

### DIFF
--- a/domains
+++ b/domains
@@ -340,6 +340,7 @@ eultech.fnac.com
 evyy.net
 fi-go.kelkoogroup.net
 fr-go.kelkoogroup.net
+go.flx1.com
 go.microsoft.com
 go.nordlocker.net
 go.nordvpn.net


### PR DESCRIPTION
The domain go.flx1.com is used to track newsletters' links: `https://go.flx1.com/click`.