### PR TITLE
Add `intercom-clicks.com` domain

### DIFF
--- a/domains
+++ b/domains
@@ -356,6 +356,7 @@ hu-go.kelkoogroup.net
 hubspotemail.net
 ie-go.kelkoogroup.net
 image.email.microsoftemail.com
+intercom-clicks.com
 it-go.kelkoogroup.net
 jdoqocy.com
 k.cocooncenter.com


### PR DESCRIPTION
[Intercom](https://www.intercom.com) uses `[companyname].intercom-clicks.com` for URLs in emails/newsletters.